### PR TITLE
Implement rule-based product classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # product_classification
-This project is to classify retail products using Google Taxonomy as a lookup.
+
+This project provides a simple rule-based classifier that attempts to map retail products to the Google product taxonomy. The classifier matches keywords in the product title, description and size description to a small set of categories.
+
+## Installation
+
+This project has no external dependencies. Clone the repository and run the classifier directly with Python 3.
+
+```bash
+python -m product_classifier.classifier --title "Men's Running Shoes" --description "Comfortable athletic shoes" --size "US 10"
+```
+
+## Testing
+
+Run the unit tests using `pytest`:
+
+```bash
+pytest
+```

--- a/product_classifier/classifier.py
+++ b/product_classifier/classifier.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Optional
+
+from .taxonomy import TAXONOMY_KEYWORDS
+
+
+def identify_google_taxonomy(title: str, description: str, size: str = "", image_path: Optional[str] = None) -> str:
+    """Identify the Google Taxonomy for a product.
+
+    Args:
+        title: Product title.
+        description: Product description.
+        size: Optional size information.
+        image_path: Optional path to an image file. This module does not
+            analyse the image but checks whether the path exists.
+
+    Returns:
+        A string representing the best matching Google Taxonomy category.
+    """
+    text = f"{title} {description} {size}".lower()
+
+    # Basic validation of the image path if provided
+    if image_path and not os.path.exists(image_path):
+        raise FileNotFoundError(f"Image file not found: {image_path}")
+
+    scores = {}
+    for category, keywords in TAXONOMY_KEYWORDS.items():
+        scores[category] = sum(1 for kw in keywords if kw in text)
+
+    # Determine the category with the highest score
+    best_category = max(scores, key=scores.get)
+
+    if scores[best_category] == 0:
+        return "Unknown"
+
+    return best_category
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Classify a retail product using Google Taxonomy keywords")
+    parser.add_argument("--title", required=True, help="Product title")
+    parser.add_argument("--description", required=True, help="Product description")
+    parser.add_argument("--size", default="", help="Size description")
+    parser.add_argument("--image", help="Path to product image")
+    args = parser.parse_args(argv)
+
+    category = identify_google_taxonomy(args.title, args.description, args.size, args.image)
+    print(category)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/product_classifier/taxonomy.py
+++ b/product_classifier/taxonomy.py
@@ -1,0 +1,22 @@
+TAXONOMY_KEYWORDS = {
+    "Apparel & Accessories": [
+        "shirt", "dress", "shoe", "pants", "jeans", "jacket", "coat", "clothing",
+        "apparel", "sock", "hat", "scarf", "glove"
+    ],
+    "Electronics": [
+        "phone", "laptop", "camera", "tablet", "computer", "tv", "television",
+        "speaker", "headphone", "electronics", "charger", "usb"
+    ],
+    "Home & Garden": [
+        "sofa", "table", "chair", "cushion", "garden", "kitchen", "cookware",
+        "bed", "pillow", "mattress", "home", "furniture"
+    ],
+    "Sports & Outdoors": [
+        "ball", "racket", "bike", "bicycle", "helmet", "glove", "fitness",
+        "sport", "outdoor", "camp", "camping", "hiking"
+    ],
+    "Health & Beauty": [
+        "makeup", "lotion", "cream", "shampoo", "soap", "health", "beauty",
+        "perfume", "skin", "hair"
+    ]
+}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,20 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from product_classifier.classifier import identify_google_taxonomy
+
+
+def test_apparel_classification():
+    category = identify_google_taxonomy(
+        title="Men's Running Shoes",
+        description="Comfortable athletic shoes for running",
+        size="US 10"
+    )
+    assert category == "Apparel & Accessories"
+
+
+def test_unknown_classification():
+    category = identify_google_taxonomy(
+        title="Mystery Item",
+        description="This product does not match any known category",
+        size=""
+    )
+    assert category == "Unknown"


### PR DESCRIPTION
## Summary
- implement a small rule-based classifier using keyword matches
- include command line interface
- provide a simple Google taxonomy keyword list
- document usage in README
- add tests for classifier logic

## Testing
- `pytest -q`
- `python -m product_classifier.classifier -h`

------
https://chatgpt.com/codex/tasks/task_e_68692122b7608330a9f0c686ed90f7eb