### PR TITLE
Add LLM classifier option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # product_classification
 
-This project provides a simple rule-based classifier that attempts to map retail products to the Google product taxonomy. The classifier matches keywords in the product title, description and size description to a small set of categories.
+This project provides a product classifier that attempts to map retail products to the Google product taxonomy. By default the classifier uses an open source language model to perform zero-shot classification and falls back to a simple keyword based approach if the model or its dependencies are unavailable.
 
 ## Installation
 
-This project has no external dependencies. Clone the repository and run the classifier directly with Python 3.
+Install the optional dependency `transformers` to enable the language model based classifier:
+
+```bash
+pip install transformers
+```
+
+After installing, run the classifier directly with Python 3.
 
 ```bash
 python -m product_classifier.classifier --title "Men's Running Shoes" --description "Comfortable athletic shoes" --size "US 10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+transformers


### PR DESCRIPTION
## Summary
- integrate a zero-shot classifier using the open source `facebook/bart-large-mnli` model
- fall back to the previous keyword approach when LLM dependencies are missing
- document new behaviour and dependency in README
- add a `requirements.txt` listing `transformers`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869231c4964833092712e6a6edb9e6c