### PR TITLE
Add Streamlit UI for product classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ Run the unit tests using `pytest`:
 ```bash
 pytest
 ```
+
+## Streamlit UI
+
+Install the optional dependency `streamlit` and launch the interactive interface:
+
+```bash
+pip install streamlit
+streamlit run product_classifier/streamlit_ui.py
+```

--- a/product_classifier/streamlit_ui.py
+++ b/product_classifier/streamlit_ui.py
@@ -1,0 +1,26 @@
+import streamlit as st
+
+from .classifier import identify_google_taxonomy
+
+
+def main() -> None:
+    st.title("Product Classification")
+    st.write("Enter product details to classify them using the Google product taxonomy.")
+
+    title = st.text_input("Product Title")
+    description = st.text_area("Description")
+    size = st.text_input("Size", "")
+
+    if st.button("Classify"):
+        if not title or not description:
+            st.warning("Please provide both a title and description.")
+        else:
+            try:
+                category = identify_google_taxonomy(title, description, size)
+                st.success(f"Category: {category}")
+            except Exception as exc:
+                st.error(f"Error: {exc}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 transformers
+streamlit


### PR DESCRIPTION
## Summary
- add a simple Streamlit app for classifying products
- document Streamlit usage in README
- include streamlit as an optional requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692f2eff8c8330b36c15d35b4751d0